### PR TITLE
Fix NPE if commands section is empty

### DIFF
--- a/src/main/kotlin/me/cookie/randomoccurrences/OccurrenceManager.kt
+++ b/src/main/kotlin/me/cookie/randomoccurrences/OccurrenceManager.kt
@@ -172,14 +172,13 @@ class OccurrenceManager(val plugin: RandomOccurrences) {
         }
 
         // Occurrence start/end events
-        config.getConfigurationSection("occurrence-start-events")!!.getKeys(false).forEach {
-            if(config.getConfigurationSection("occurrence-start-events.commands") != null){
-                config.getConfigurationSection("occurrence-start-events.commands")!!.getKeys(false).forEach { command ->
-                    occurrenceStartCommands.add(compileExecutableCommand(
+        config.getConfigurationSection("occurrence-start-events")!!.getKeys(false).forEach { _ ->
+            config.getConfigurationSection("occurrence-start-events.commands")?.getKeys(false)?.forEach { command ->
+                occurrenceStartCommands.add(compileExecutableCommand(
                         config.getConfigurationSection("occurrence-start-events.commands.$command")!!
-                    ))
-                }
+                ))
             }
+
             config.getConfigurationSection("occurrence-start-events.sound")?.let {
                 occurrenceStartSound = PlayableSound(
                     Sound.valueOf(it.getString("sound", "ENTITY_EXPERIENCE_ORB_PICKUP")!!),
@@ -189,14 +188,13 @@ class OccurrenceManager(val plugin: RandomOccurrences) {
             }
         }
 
-        config.getConfigurationSection("occurrence-end-events")!!.getKeys(false).forEach {
-            if(config.getConfigurationSection("occurrence-start-events.commands") != null){
-                config.getConfigurationSection("occurrence-end-events.commands")!!.getKeys(false).forEach { command ->
-                    occurrenceEndCommands.add(compileExecutableCommand(
-                            config.getConfigurationSection("occurrence-end-events.commands.$command")!!
-                    ))
-                }
+        config.getConfigurationSection("occurrence-end-events")!!.getKeys(false).forEach { _ ->
+            config.getConfigurationSection("occurrence-end-events.commands")?.getKeys(false)?.forEach { command ->
+                occurrenceEndCommands.add(compileExecutableCommand(
+                        config.getConfigurationSection("occurrence-end-events.commands.$command")!!
+                ))
             }
+
             config.getConfigurationSection("occurrence-end-events.sound")?.let {
                 occurrenceEndSound = PlayableSound(
                     Sound.valueOf(it.getString("sound", "ENTITY_PLAYER_LEVELUP")!!),

--- a/src/main/kotlin/me/cookie/randomoccurrences/OccurrenceManager.kt
+++ b/src/main/kotlin/me/cookie/randomoccurrences/OccurrenceManager.kt
@@ -172,11 +172,13 @@ class OccurrenceManager(val plugin: RandomOccurrences) {
         }
 
         // Occurrence start/end events
-        config.getConfigurationSection("occurrence-start-events")!!.getKeys(false).forEach { event ->
-            config.getConfigurationSection("occurrence-start-events.commands")!!.getKeys(false).forEach { command ->
-                occurrenceStartCommands.add(compileExecutableCommand(
-                    config.getConfigurationSection("occurrence-start-events.commands.$command")!!
-                ))
+        config.getConfigurationSection("occurrence-start-events")!!.getKeys(false).forEach {
+            if(config.getConfigurationSection("occurrence-start-events.commands") != null){
+                config.getConfigurationSection("occurrence-start-events.commands")!!.getKeys(false).forEach { command ->
+                    occurrenceStartCommands.add(compileExecutableCommand(
+                        config.getConfigurationSection("occurrence-start-events.commands.$command")!!
+                    ))
+                }
             }
             config.getConfigurationSection("occurrence-start-events.sound")?.let {
                 occurrenceStartSound = PlayableSound(
@@ -187,11 +189,13 @@ class OccurrenceManager(val plugin: RandomOccurrences) {
             }
         }
 
-        config.getConfigurationSection("occurrence-end-events")!!.getKeys(false).forEach { event ->
-            config.getConfigurationSection("occurrence-end-events.commands")!!.getKeys(false).forEach { command ->
-                occurrenceEndCommands.add(compileExecutableCommand(
-                    config.getConfigurationSection("occurrence-end-events.commands.$command")!!
-                ))
+        config.getConfigurationSection("occurrence-end-events")!!.getKeys(false).forEach {
+            if(config.getConfigurationSection("occurrence-start-events.commands") != null){
+                config.getConfigurationSection("occurrence-end-events.commands")!!.getKeys(false).forEach { command ->
+                    occurrenceEndCommands.add(compileExecutableCommand(
+                            config.getConfigurationSection("occurrence-end-events.commands.$command")!!
+                    ))
+                }
             }
             config.getConfigurationSection("occurrence-end-events.sound")?.let {
                 occurrenceEndSound = PlayableSound(


### PR DESCRIPTION
Hello, if you set the **commands** section empty, will throw a NullPointerException and plugin will fail to load!


**The config section**

```
occurrence-start-events:
  sound:
    sound: ENTITY_EXPERIENCE_ORB_PICKUP
    volume: 1
    pitch: 1.4
  commands: []
  ```

**The error:**
```
[16:00:33] [Server thread/ERROR]: Error occurred while enabling RandomOccurrences v1.6.0 (Is it up to date?)
java.lang.NullPointerException: null
	at me.cookie.randomoccurrences.OccurrenceManager.compileConfig(OccurrenceManager.kt:176) ~[RandomOccurrences-1.6.0.jar:?]
	at me.cookie.randomoccurrences.OccurrenceManager.<init>(OccurrenceManager.kt:30) ~[RandomOccurrences-1.6.0.jar:?]
	at me.cookie.randomoccurrences.RandomOccurrences.onEnable(RandomOccurrences.kt:26) ~[RandomOccurrences-1.6.0.jar:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:371) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:548) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugin(CraftServer.java:611) ~[purpur-1.19.2.jar:git-Purpur-1832]
	at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugins(CraftServer.java:525) ~[purpur-1.19.2.jar:git-Purpur-1832]
	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:641) ~[purpur-1.19.2.jar:git-Purpur-1832]
	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:427) ~[purpur-1.19.2.jar:git-Purpur-1832]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:343) ~[purpur-1.19.2.jar:git-Purpur-1832]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1116) ~[purpur-1.19.2.jar:git-Purpur-1832]
	at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:310) ~[purpur-1.19.2.jar:git-Purpur-1832]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
[16:00:33] [Server thread/INFO]: [RandomOccurrences] Disabling RandomOccurrences v1.6.0
```

**Tested and works as expected!**

EDIT: The latest commit is done checking null safety of Kotlin instead of the Java. (I never used Kotlin srry)